### PR TITLE
Attributes on elements are always lower-case.

### DIFF
--- a/clearable-input.html
+++ b/clearable-input.html
@@ -11,7 +11,7 @@
 <link rel="import" href="../polymer/polymer.html"/>
 <link rel="import" href="../core-icons/core-icons.html">
 
-<polymer-element name="clearable-input" attributes="placeholder value readonly isDisabled backgroundColor color icon">
+<polymer-element name="clearable-input" attributes="placeholder value readonly isdisabled backgroundColor color icon">
 	<template>
 		<style>
 			span.wrapper {
@@ -113,7 +113,7 @@
 		            * @type boolean
 		            * @default undefined
 		            */
-					this.$.textInput.disabled = (this.isDisabled !== void 0);
+					this.$.textInput.disabled = (this.isdisabled !== void 0);
 					/**
 		            * The core-icon that's used for clearing the input text
 		            *
@@ -127,7 +127,7 @@
 					}
 
 					setInterval(function() {
-						this.clearHidden = this.$.textInput.value.length === 0 || this.isDisabled !== void 0;
+						this.clearHidden = this.$.textInput.value.length === 0 || this.isdisabled !== void 0;
 					}.bind(this), 100);
 
 
@@ -142,7 +142,7 @@
 				* returns boolean
 				*/
 				testClearInput: function() {
-					if(this.isDisabled === void 0) {
+					if(this.isdisabled === void 0) {
 						this.clearInput();
 						return true;
 					}


### PR DESCRIPTION
Chrome and Firefox interpret this fine, but IE goes all strict and chokes.
